### PR TITLE
修复多屏截图崩溃、无法截图、光标显示错误等问题

### DIFF
--- a/Screenote/Note.cs
+++ b/Screenote/Note.cs
@@ -25,8 +25,8 @@ namespace Screenote
         private Size NoteSize;
         private bool ResizeWindow = false;
         private int WindowRight, WindowBottom;
+        private MouseButtons lastMousePressButton = MouseButtons.None;
         private const int edge = 6;
-
 
         public Note(Bitmap bitmap, Point location, Size size)
         {
@@ -66,6 +66,7 @@ namespace Screenote
 
         private void Note_MouseDown(object sender, MouseEventArgs e)
         {
+            lastMousePressButton = e.Button;
             if (e.Button == MouseButtons.Left)
             {
                 if ((Control.MousePosition.X - this.Location.X < edge) || ((this.Location.X + this.Width) - Control.MousePosition.X < edge) || (Control.MousePosition.Y - this.Location.Y < edge) || ((this.Location.Y + this.Height) - Control.MousePosition.Y < edge))
@@ -80,12 +81,6 @@ namespace Screenote
                     MoveY = e.Y + 1;
                     MoveWindow = true;
                 }
-            }
-            else if (e.Button == MouseButtons.Right)
-            {
-                picture.BackgroundImage.Dispose();
-                this.Close();
-                GC.Collect();
             }
             else if (e.Button == MouseButtons.Middle)
             {
@@ -102,6 +97,13 @@ namespace Screenote
             else if (MoveWindow == true)
             {
                 MoveWindow = false;
+            }
+            if (lastMousePressButton == MouseButtons.Right)
+            {
+                lastMousePressButton = MouseButtons.None;
+                picture.BackgroundImage.Dispose();
+                this.Close();
+                GC.Collect();
             }
         }
 
@@ -309,9 +311,11 @@ namespace Screenote
                     break;
                 case Keys.Space:
                     Note_MouseDown(this, new MouseEventArgs(MouseButtons.Middle, 0, Cursor.Position.X, Cursor.Position.Y, 0));
+                    Note_MouseUp(this, null);
                     break;
                 case Keys.Escape:
                     Note_MouseDown(this, new MouseEventArgs(MouseButtons.Right, 0, Cursor.Position.X, Cursor.Position.Y, 0));
+                    Note_MouseUp(this, null);
                     break;
                 case Keys.Enter:
                     Note_DoubleClick(this, new EventArgs());

--- a/Screenote/Screen.cs
+++ b/Screenote/Screen.cs
@@ -282,8 +282,8 @@ namespace Screenote
             }
             var pixel = bitmapScreen.GetPixel(X, Y);
             var infoStr = $"RGB: {pixel.R, 2:X2}{pixel.G, 2:X2}{pixel.B, 2:X2}\n";
-            var dx = Cursor.Position.X - Location.X - startPos.X;
-            var dy = Cursor.Position.Y - Location.X - startPos.Y;
+            var dx = X - startPos.X;
+            var dy = Y - startPos.Y;
 
             if (shot) infoStr += $"{Math.Abs(dx), 4},{Math.Abs(dy), 4}";
             graphicsMagnifier.DrawString(infoStr, new Font("Consolas", 8), new SolidBrush(Color.FromArgb(255, 150, 0)), new Point(0, 0));

--- a/Screenote/Screen.cs
+++ b/Screenote/Screen.cs
@@ -228,7 +228,10 @@ namespace Screenote
         {
             if (shot)
             {
-                Point MouseEnd = e.Location;
+                Point MouseEnd = new Point(
+                    Math.Max(Math.Min(e.Location.X, this.Width - 1), 0),
+                    Math.Max(Math.Min(e.Location.Y, this.Height - 1), 0)
+                );
                 int width = Math.Abs(MouseEnd.X - MouseStart.X) + 1;
                 int height = Math.Abs(MouseEnd.Y - MouseStart.Y) + 1;
                 if (width > 15 && height > 15)
@@ -257,10 +260,10 @@ namespace Screenote
                 Y + 150 > this.Height ? Y - 150 : Y + 50
             );
             magnifier.Visible = true;
-
-            int left = X - 12 < 0 ? 12 - X : 0;
+            // Invalid area(width) around the cursor
+            int left = X < 12 ? 12 - X : 0;
             int right = X + 13 > this.Width ? (X + 13 - this.Width) : 0;
-            int top = Y - 12 < 0 ? 12 - Y : 0;
+            int top = Y < 12 ? 12 - Y : 0;
             int bottom = Y + 13 > this.Height ? (Y + 13 - this.Height) : 0;
 
             Rectangle region = new Rectangle(X - 12 + left, Y - 12 + top, 25 - right, 25 - bottom);


### PR DESCRIPTION
在多个屏幕上使用此软件时，跨屏幕截图、副屏上截图会出现问题，原因是整个屏幕坐标与窗口坐标为两个系统（代码中Location、Position属性）
最后四处为代码宽度太大的修改，可忽略